### PR TITLE
Adds a few methods for setting additional data

### DIFF
--- a/lib/paypal-express-checkout.js
+++ b/lib/paypal-express-checkout.js
@@ -89,7 +89,7 @@ Paypal.prototype.getExpressCheckoutDetails = function(token, doPayment, callback
 		}
 
 		var params = self.params();
-		params.PAYMENTACTION = 'Sale';
+		params.PAYMENTREQUEST_0_PAYMENTACTION = params.PAYMENTREQUEST_0_PAYMENTACTION || 'Sale';
 		params.PAYERID = data.PAYERID;
 		params.TOKEN = token;
 		params.PAYMENTREQUEST_0_AMT = data.PAYMENTREQUEST_0_AMT;
@@ -124,6 +124,36 @@ Paypal.prototype.setProducts = function(products) {
 	this.products = products;
 	return this;
 };
+
+Paypal.prototype.setPaymentAction = function(paymentAction){
+	this.payOptions.PAYMENTREQUEST_0_PAYMENTACTION = paymentAction;
+	return this;
+}
+
+Paypal.prototype.setShippingAmount = function(amount){
+	this.payOptions.PAYMENTREQUEST_0_SHIPPINGAMT = parseFloat(amount);
+	return this;
+}
+
+Paypal.prototype.setSubTotal = function(amount){
+	this.payOptions.PAYMENTREQUEST_0_ITEMAMT = parseFloat(amount);
+	return this;
+}
+
+Paypal.prototype.setTaxAmount = function(amount){
+	this.payOptions.PAYMENTREQUEST_0_TAXAMT = parseFloat(amount);
+	return this;
+}
+
+Paypal.prototype.setMaxAmount = function(amount){
+	this.payOptions.MAXAMT = parseFloat(amount);
+	return this
+}
+
+Paypal.prototype.clearData = function(){
+	this.payOptions = {};
+	this.products = [];
+}
 
 /**
  * Get Items params.
@@ -176,7 +206,7 @@ Paypal.prototype.setExpressCheckoutPayment = function(email, invoiceNumber, amou
 	params.PAYMENTREQUEST_0_CURRENCYCODE = currency;
 	params.PAYMENTREQUEST_0_INVNUM = invoiceNumber;
 	params.PAYMENTREQUEST_0_CUSTOM = invoiceNumber + '|' + params.PAYMENTREQUEST_0_AMT + '|' + currency;
-	params.PAYMENTREQUEST_0_PAYMENTACTION = 'Sale';
+	// params.PAYMENTREQUEST_0_PAYMENTACTION = 'Sale';
 	params.PAYMENTREQUEST_0_ITEMAMT = prepareNumber(amount);
 
 	params = _.extend(params, this.getItemsParams());

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "paypal-express-checkout-simple",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "Simple implementation of paypal express checkout so you can quickly start using Paypal. Supports only basics to sell items.",
   "main": "./index.js",
   "scripts": {

--- a/test/paypal-express-checkout.js
+++ b/test/paypal-express-checkout.js
@@ -142,4 +142,63 @@ describe('Test paypal-express-checkout', function() {
 			done();
 		});
 	});
+
+	/**
+	 * Additional valid pay calls.
+	 * @param  {[type]} done) {	}         [description]
+	 * @return {[type]}       [description]
+	 */
+	it('should test valid pay call setting amount,payment action, subtotal, max amount plus product info', function(done) {
+		fakeRequest.end = function(params) {
+			assert.ok(params.indexOf('PAYMENTREQUEST_0_AMT=1000.99') !== -1);
+			assert.ok(params.indexOf('EMAIL=test%40email.com') !== -1);
+			assert.ok(params.indexOf('HDRIMG=http%3A%2F%2Fhdrimage.jpg') !== -1);
+			assert.ok(params.indexOf('LOGOIMG=http%3A%2F%2Flogoimg.jpg') !== -1);
+			assert.ok(params.indexOf('PAYFLOWCOLOR=ff00ff') !== -1);
+			assert.ok(params.indexOf('CARTBORDERCOLOR=ffffff') !== -1);
+			assert.ok(params.indexOf('REQCONFIRMSHIPPING=1') !== -1);
+			assert.ok(params.indexOf('NOSHIPPING=0') !== -1);
+			assert.ok(params.indexOf('ALLOWNOTE=1') !== -1);
+			assert.ok(params.indexOf('SOLUTIONTYPE=Sole') !== -1);
+			assert.ok(params.indexOf('L_PAYMENTREQUEST_0_NAME0=product1') !== -1);
+			assert.ok(params.indexOf('L_PAYMENTREQUEST_0_NAME1=product2') !== -1);
+			assert.ok(params.indexOf('L_PAYMENTREQUEST_0_AMT0=10.99') !== -1);
+			assert.ok(params.indexOf('L_PAYMENTREQUEST_0_QTY0=10') !== -1);
+			assert.ok(params.indexOf('L_PAYMENTREQUEST_0_DESC0=description1') !== -1);
+			assert.ok(params.indexOf('RETURNURL=returnUrl') !== -1);
+			assert.ok(params.indexOf('CANCELURL=cancelUrl') !== -1);
+			assert.ok(params.indexOf('PAYMENTREQUEST_0_PAYMENTACTION=Authorization') !== -1);
+			assert.ok(params.indexOf('PAYMENTREQUEST_0_SHIPPINGAMT=12.99') !== -1);
+			assert.ok(params.indexOf('PAYMENTREQUEST_0_TAXAMT=1.49') !== -1);
+			assert.ok(params.indexOf('MAXAMT=1200.99') !== -1);
+		};
+
+		var paypal = Paypal.create('username', 'pswd', 'signature');
+		paypal.setPayOptions('MyBrand', 'http://hdrimage.jpg', 'http://logoimg.jpg', 'ff00ff', 'ffffff', true, false, true);
+		paypal.setProducts([ 
+			{
+				name: 'product1', 
+				description: 'description1', 
+				quantity: 10, 
+				amount: 10.99
+			},
+			{
+				name: 'product2', 
+				description: 'description2', 
+				quantity: 10, 
+				amount: 1000.99
+			},
+			]);
+		paypal.setPaymentAction('Authorization');
+		paypal.setShippingAmount(12.99);
+		paypal.setSubTotal(1000.99);
+		paypal.setTaxAmount(1.49);
+		paypal.setMaxAmount(1200.99);
+
+		paypal.setExpressCheckoutPayment('test@email.com', '001', 1000.99, 'Some description', 'USD', 'returnUrl', 'cancelUrl', false, function(err, data) {
+			console.log('Redirect to paypal: ' + data.redirectUrl);
+			assert.ok(data.redirectUrl.indexOf('new_token') !== -1);
+			done();
+		});
+	});
 });


### PR DESCRIPTION
Currently it's not possible to set the payment action, the tax amount, max amount or the shipping amount without just setting setting the `payOptions` object explicitly like this:

```
paypal.payOptions = {
    PAYMENTREQUEST_0_SHIPPINGAMT: 4.99,
    PAYMENTREQUEST_0_PAYMENTACTION: 'Authorization',
    PAYMENTREQUEST_0_TAXAMT: 12.45,
    MAXAMT: 99.00
}
```

This pull request adds methods for adding those using methods to avoid accidentally overwriting any of the other options set on the `payOptions` object.

```
paypal.setShippingAmount(4.99)
    .setPaymentAction('Authorization')
    .setTaxAmount(12.45)
    .setMaxAmount(99.99);
```
